### PR TITLE
fix: remove upstream clone, upgrade actions to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,13 @@ on:
   pull_request:
     paths: ['python/**', 'tests/**']
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
@@ -36,8 +33,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: unit-tests
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
@@ -63,7 +60,7 @@ jobs:
       version: ${{ steps.version.outputs.semver }}
       tag: ${{ steps.version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -80,22 +77,20 @@ jobs:
           echo "semver=0.9.8.$NEXT" >> "$GITHUB_OUTPUT"
           echo "Next version: v0.9.8.$NEXT (previous: $LATEST)"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           tags: ghcr.io/nafania/agent-zero:${{ steps.version.outputs.tag }}
-          build-args: |
-            A0_VERSION=${{ steps.version.outputs.tag }}
-            BRANCH=main
+          build-args: A0_VERSION=${{ steps.version.outputs.tag }}
 
       - name: Create and push tag
         run: |
@@ -108,7 +103,7 @@ jobs:
     needs: build-and-release
     steps:
       - name: Trigger hassio addon update
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.HASSIO_DISPATCH_TOKEN }}
           repository: Nafania/agent-zero-hassio

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,7 @@ RUN bash /ins/after_install.sh
 # --- Run image scripts ---
 COPY ./docker/run/fs/ /
 
-ARG BRANCH=local
-ENV BRANCH=$BRANCH
-
-RUN bash /ins/pre_install.sh $BRANCH
+RUN bash /ins/pre_install.sh
 
 # --- Python deps (cached unless requirements*.txt change) ---
 COPY requirements.txt requirements2.txt /tmp/deps/
@@ -37,7 +34,7 @@ RUN bash -c '. /ins/setup_venv.sh && \
     rm -rf /tmp/deps'
 
 # --- Playwright (cached with deps layer) ---
-RUN bash /ins/install_playwright.sh $BRANCH
+RUN bash /ins/install_playwright.sh
 
 # --- Bun (rarely changes) ---
 RUN apt-get update && apt-get install -y --no-install-recommends unzip \
@@ -52,9 +49,9 @@ ARG A0_VERSION=unknown
 RUN echo "$A0_VERSION" > /git/agent-zero/VERSION
 
 # Verify deps are installed (near-instant, preload moved to runtime)
-RUN bash /ins/install_A0.sh $BRANCH
+RUN bash /ins/install_A0.sh
 
-RUN bash /ins/post_install.sh $BRANCH
+RUN bash /ins/post_install.sh
 
 # --- Code snapshot for persistent-volume overlay at runtime ---
 RUN mkdir -p /a0 && cp -rn --no-preserve=ownership,mode /git/agent-zero/. /a0

--- a/docker/run/fs/ins/install_A0.sh
+++ b/docker/run/fs/ins/install_A0.sh
@@ -1,45 +1,9 @@
 #!/bin/bash
 set -e
 
-# Exit immediately if a command exits with a non-zero status.
-# set -e
+. "/ins/setup_venv.sh"
 
-# branch from parameter
-if [ -z "$1" ]; then
-    echo "Error: Branch parameter is empty. Please provide a valid branch name."
-    exit 1
-fi
-BRANCH="$1"
-
-if [ "$BRANCH" = "local" ]; then
-    # For local branch, use the files
-    echo "Using local dev files in /git/agent-zero"
-    # List all files recursively in the target directory
-    # echo "All files in /git/agent-zero (recursive):"
-    # find "/git/agent-zero" -type f | sort
-else
-    # For other branches, clone from GitHub
-    echo "Cloning repository from branch $BRANCH..."
-    git clone -b "$BRANCH" "https://github.com/agent0ai/agent-zero" "/git/agent-zero" || {
-        echo "CRITICAL ERROR: Failed to clone repository. Branch: $BRANCH"
-        exit 1
-    }
-fi
-
-. "/ins/setup_venv.sh" "$@"
-
-# moved to base image
-# # Ensure the virtual environment and pip setup
-# pip install --upgrade pip ipython requests
-# # Install some packages in specific variants
-# pip install torch --index-url https://download.pytorch.org/whl/cpu
-
-# Install remaining A0 python packages
 uv pip install -r /git/agent-zero/requirements.txt
-# override for packages that have unnecessarily strict dependencies
 uv pip install -r /git/agent-zero/requirements2.txt
 
-# install playwright
-bash /ins/install_playwright.sh "$@"
-
-# Preload moved to runtime (run_A0.sh) to speed up Docker builds
+bash /ins/install_playwright.sh

--- a/docker/run/fs/ins/install_A02.sh
+++ b/docker/run/fs/ins/install_A02.sh
@@ -1,17 +1,8 @@
 #!/bin/bash
 set -e
 
-# cachebuster script, this helps speed up docker builds
+bash /ins/install_A0.sh
 
-# remove repo (if not local branch)
-if [ "$1" != "local" ]; then
-    rm -rf /git/agent-zero
-fi
-
-# run the original install script again
-bash /ins/install_A0.sh "$@"
-
-# remove python packages cache
-. "/ins/setup_venv.sh" "$@"
+. "/ins/setup_venv.sh"
 pip cache purge
 uv cache prune

--- a/docker/run/fs/ins/install_playwright.sh
+++ b/docker/run/fs/ins/install_playwright.sh
@@ -2,7 +2,7 @@
 set -e
 
 # activate venv
-. "/ins/setup_venv.sh" "$@"
+. "/ins/setup_venv.sh"
 
 # install playwright if not installed (should be from requirements.txt)
 uv pip install playwright

--- a/docker/run/fs/ins/pre_install.sh
+++ b/docker/run/fs/ins/pre_install.sh
@@ -10,4 +10,4 @@ if [ -f /etc/cron.d/* ]; then
 fi
 
 # Prepare SSH daemon
-bash /ins/setup_ssh.sh "$@"
+bash /ins/setup_ssh.sh


### PR DESCRIPTION
## Summary

Fixes the Docker build failure from PR #3 and properly resolves Node.js 20 deprecation.

**Upstream clone removed:**
- `install_A0.sh` — removed `git clone agent0ai/agent-zero` branch; always uses local files (already in image via `COPY`)
- `install_A02.sh` — removed `rm -rf /git/agent-zero` (no clone = nothing to re-fetch)
- `Dockerfile` — removed `ARG BRANCH` / `ENV BRANCH`, all scripts called without branch parameter
- `pre_install.sh`, `install_playwright.sh` — removed unused `$@` passthrough

**Actions upgraded to Node.js 24 (native support):**
- `actions/checkout` v4 → v5
- `actions/setup-python` v5 → v6
- `docker/setup-buildx-action` v3 → v4
- `docker/login-action` v3 → v4
- `docker/build-push-action` v6 → v7
- `peter-evans/repository-dispatch` v3 → v4
- Removed `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workaround (no longer needed)

## Test plan

- [ ] Merge and verify `build-and-release` job completes (Docker build succeeds without upstream clone)
- [ ] Verify no Node.js 20 deprecation warnings in Actions output
- [ ] Verify git tag `v0.9.8.19` is created and Docker image pushed to GHCR
- [ ] Verify `notify-hassio` triggers dispatch to `agent-zero-hassio`


Made with [Cursor](https://cursor.com)