### PR TITLE
fix: memory dashboard Area filter not working

### DIFF
--- a/webui/components/modals/memory/memory-dashboard.html
+++ b/webui/components/modals/memory/memory-dashboard.html
@@ -64,12 +64,12 @@
 
                     <div class="filter-group-inline filter-area">
                         <label for="area-filter">Area</label>
-                        <select id="area-filter" x-model="$store.memoryDashboardStore.areaFilter">
+                        <select id="area-filter" x-model="$store.memoryDashboardStore.areaFilter"
+                            @change="$store.memoryDashboardStore.searchMemories()">
                             <option value="">All Areas</option>
                             <option value="main">Main</option>
                             <option value="fragments">Fragments</option>
                             <option value="solutions">Solutions</option>
-                            <option value="skills">Skills</option>
                         </select>
                     </div>
 


### PR DESCRIPTION
## Summary
- Add `@change` handler to the Area filter dropdown so selecting a different area immediately triggers a new search instead of requiring a manual "Search" button click
- Remove the unsupported "Skills" area option from the dropdown — `Memory.Area` enum only contains `main`, `fragments`, and `solutions`, so filtering by "Skills" silently returned unfiltered results

## Test plan
- [x] Open Memory Dashboard, change Area filter — verify search triggers automatically
- [x] Verify "Skills" option is no longer in the dropdown
- [x] Verify filtering by Main/Fragments/Solutions returns correct subset
- [x] Verify "All Areas" still shows everything

Made with [Cursor](https://cursor.com)