### PR TITLE
fix: show slash commands when typing / mid-text

### DIFF
--- a/webui/components/chat/input/chat-bar-input.html
+++ b/webui/components/chat/input/chat-bar-input.html
@@ -45,7 +45,7 @@
             </div>
             <textarea id="chat-input" :placeholder="$store.chatInput.activeSkill ? 'Type your message...' : $store.chatInput.inputPlaceholder" rows="1"
                       @keydown="if ($store.chatInput.activeSkill && !$store.chatInput.message && $event.key === 'Backspace') { $store.chatInput.clearSkill(); return; } if ($store.slashCommands.onKeydown($event)) return; if ($event.key === 'Enter' && !$event.shiftKey && !$event.isComposing && $event.keyCode !== 229) { $event.preventDefault(); $store.chatInput.sendMessage(); }"
-                      @input="$store.chatInput.adjustTextareaHeight(); $store.slashCommands.onInput($store.chatInput.message)"
+                      @input="$store.chatInput.adjustTextareaHeight(); $store.slashCommands.onInput($store.chatInput.message, $el.selectionStart)"
                       x-model="$store.chatInput.message"></textarea>
             <button id="expand-button" @click="$store.fullScreenInputModal.openModal()" aria-label="Expand input">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">

--- a/webui/components/chat/input/slash-commands.js
+++ b/webui/components/chat/input/slash-commands.js
@@ -63,19 +63,21 @@ const model = {
   selectedIndex: 0,
   _allCommands: [],
 
-  async onInput(value) {
-    if (!value.startsWith("/")) {
+  _slashPrefix: "",
+
+  async onInput(value, cursorPos) {
+    const textUpToCursor = typeof cursorPos === "number"
+      ? value.slice(0, cursorPos)
+      : value;
+
+    const match = textUpToCursor.match(/(?:^|\s)(\/[^\s]*)$/);
+    if (!match) {
       this.hide();
       return;
     }
 
-    const hasSpace = value.includes(" ");
-    const typed = value.split(/\s/)[0].toLowerCase();
-
-    if (hasSpace) {
-      this.hide();
-      return;
-    }
+    const typed = match[1].toLowerCase();
+    this._slashPrefix = match[1];
 
     const skills = await _fetchInstalledSkills();
     this._allCommands = [...BUILTIN_COMMANDS, ...skills];
@@ -119,14 +121,19 @@ const model = {
     if (!input) return;
 
     const store = globalThis.Alpine?.store("chatInput");
+    const prefix = this._slashPrefix || "/";
+    const msg = store ? store.message : input.value;
+    const prefixStart = msg.lastIndexOf(prefix);
+    const before = prefixStart > 0 ? msg.slice(0, prefixStart) : "";
+    const after = msg.slice(prefixStart + prefix.length);
 
     if (cmd.isSkill && store) {
       store.activeSkill = cmd.command.slice(1);
-      store.message = "";
+      store.message = (before + after).trim();
     } else if (store) {
-      store.message = cmd.command + " ";
+      store.message = before + cmd.command + " " + after;
     } else {
-      input.value = cmd.command + " ";
+      input.value = before + cmd.command + " " + after;
     }
 
     this.hide();


### PR DESCRIPTION
## Summary
- Slash command autocomplete now triggers when typing `/` anywhere in the input, not only at the start
- Uses cursor position to detect the `/token` being typed, matching against `(?:^|\s)(\/[^\s]*)$` before the cursor
- When selecting a command, the `/fragment` is replaced while preserving surrounding text

## Test plan
- [ ] Type some text, then type `/` — autocomplete should appear
- [ ] Select a skill from autocomplete — chip should appear, text preserved
- [ ] Type `/` at start of empty input — should still work as before
- [ ] Type `/` after a space mid-sentence — should show autocomplete
- [ ] Press Escape to dismiss autocomplete

Made with [Cursor](https://cursor.com)