### PR TITLE
fix: prevent browser agent from hanging the entire chat

### DIFF
--- a/python/helpers/defer.py
+++ b/python/helpers/defer.py
@@ -40,7 +40,7 @@ class EventLoopThread:
         asyncio.set_event_loop(self.loop)
         self.loop.run_forever()
 
-    def terminate(self):
+    def terminate(self, timeout: float = 5.0):
         loop = getattr(self, "loop", None)
         thread = getattr(self, "thread", None)
 
@@ -53,9 +53,9 @@ class EventLoopThread:
             else:
                 loop.call_soon_threadsafe(loop.stop)
                 if thread:
-                    thread.join()
+                    thread.join(timeout=timeout)
         elif thread and thread.is_alive() and thread is not threading.current_thread():
-            thread.join()
+            thread.join(timeout=timeout)
 
         if not loop.is_closed():
             loop.close()
@@ -144,7 +144,7 @@ class DeferredTask:
 
         return await loop.run_in_executor(None, _get_result)
 
-    def kill(self, terminate_thread: bool = False) -> None:
+    def kill(self, terminate_thread: bool = False, timeout: float = 5.0) -> None:
         """Kill the task and optionally terminate its thread."""
         self.kill_children()
         if self._future and not self._future.done():
@@ -156,11 +156,11 @@ class DeferredTask:
                     cleanup_future = asyncio.run_coroutine_threadsafe(
                         self._drain_event_loop_tasks(), self.event_loop_thread.loop
                     )
-                    cleanup_future.result()
-                except Exception:
+                    cleanup_future.result(timeout=timeout)
+                except (TimeoutError, Exception):
                     pass
 
-            self.event_loop_thread.terminate()
+            self.event_loop_thread.terminate(timeout=timeout)
 
     def kill_children(self) -> None:
         for child in self.children:

--- a/python/tools/browser_agent.py
+++ b/python/tools/browser_agent.py
@@ -113,18 +113,23 @@ class State:
 
     def kill_task(self):
         if self.task:
-            self.task.kill(terminate_thread=True)
+            self.task.kill(terminate_thread=True, timeout=5.0)
             self.task = None
         if self.browser_session:
             try:
                 import asyncio
 
                 loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                loop.run_until_complete(self.browser_session.close()) if self.browser_session else None
+                loop.run_until_complete(
+                    asyncio.wait_for(self.browser_session.close(), timeout=5.0)
+                ) if self.browser_session else None
                 loop.close()
-            except Exception as e:
-                PrintStyle().error(f"Error closing browser session: {e}")
+            except (asyncio.TimeoutError, Exception) as e:
+                PrintStyle().warning(f"Browser session close timed out or failed: {e}")
+                try:
+                    loop.close()
+                except Exception:
+                    pass
             finally:
                 self.browser_session = None
         self.use_agent = None
@@ -166,7 +171,7 @@ class State:
                 ),
                 controller=controller,
                 enable_memory=False,  # Disable memory to avoid state conflicts
-                llm_timeout=3000, # TODO rem
+                llm_timeout=120,
                 sensitive_data=cast(dict[str, str | dict[str, str]] | None, secrets_dict or {}),  # Pass secrets
             )
         except Exception as e:


### PR DESCRIPTION
## Summary

- Fix a rare but critical bug where the Browser Agent could hang the **entire** Agent Zero chat, requiring a full restart
- Root cause: synchronous blocking calls without timeouts in the browser task cleanup path (`kill_task()`) — when Playwright or the LLM hangs, `cleanup_future.result()`, `thread.join()`, and `browser_session.close()` block the main event loop indefinitely
- All three blocking operations now have 5-second timeouts, so cleanup completes in ≤15s even if the browser is stuck
- Removed erroneous `asyncio.set_event_loop()` call that corrupted the main thread's event loop reference
- Reduced `llm_timeout` from 3000s (50 minutes!) to 120s

## Files changed

| File | Change |
|------|--------|
| `python/helpers/defer.py` | Add `timeout` param to `DeferredTask.kill()` and `EventLoopThread.terminate()` |
| `python/tools/browser_agent.py` | Add timeout to `browser_session.close()`, remove `set_event_loop`, fix `llm_timeout` |

## Test plan

- [ ] Start a browser agent task and let it complete normally — verify it still works
- [ ] Start a browser agent task, send a nudge mid-execution — verify intervention works
- [ ] Simulate a hanging browser task (e.g. unreachable LLM endpoint) — verify the chat recovers after timeout instead of freezing
- [ ] Verify no regressions in existing agent functionality


Made with [Cursor](https://cursor.com)