### PR TITLE
fix: prevent "Too many open files" crash from LanceDB/Cognee searches

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -2,8 +2,20 @@ from python.helpers import dotenv, runtime, settings
 import asyncio
 import string
 import random
+import resource
 from python.helpers.print_style import PrintStyle
 
+
+# Raise the file-descriptor soft limit to avoid "Too many open files" from LanceDB/Cognee
+_FD_TARGET = 65536
+try:
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if soft < _FD_TARGET:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (min(_FD_TARGET, hard), hard))
+        new_soft, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+        PrintStyle.standard(f"Raised file descriptor limit: {soft} -> {new_soft}")
+except Exception as e:
+    PrintStyle.warning(f"Could not raise file descriptor limit: {e}")
 
 PrintStyle.standard("Preparing environment...")
 

--- a/python/extensions/message_loop_prompts_after/_50_recall_memories.py
+++ b/python/extensions/message_loop_prompts_after/_50_recall_memories.py
@@ -112,8 +112,17 @@ class RecallMemories(Extension):
                     session_id=session_id,
                 ),
             )
+        except OSError as e:
+            try:
+                PrintStyle.error(f"cognee.search OS error (likely too many open files): {e}")
+            except OSError:
+                pass
+            mem_answers, sol_answers = [], []
         except Exception as e:
-            PrintStyle.error(f"cognee.search failed: {e}")
+            try:
+                PrintStyle.error(f"cognee.search failed: {e}")
+            except OSError:
+                pass
             mem_answers, sol_answers = [], []
 
         memories = _to_strings(mem_answers, set["memory_recall_memories_max_result"])

--- a/python/extensions/message_loop_prompts_after/_91_recall_wait.py
+++ b/python/extensions/message_loop_prompts_after/_91_recall_wait.py
@@ -27,11 +27,20 @@ class RecallWait(Extension):
             try:
                 await task
             except (TimeoutError, asyncio.TimeoutError):
-                PrintStyle.error("Memory recall timed out, continuing without memories")
+                try:
+                    PrintStyle.error("Memory recall timed out, continuing without memories")
+                except OSError:
+                    pass
             except asyncio.CancelledError:
-                PrintStyle.error("Memory recall was cancelled")
+                try:
+                    PrintStyle.error("Memory recall was cancelled")
+                except OSError:
+                    pass
             except Exception as e:
-                PrintStyle.error(f"Memory recall failed: {e}")
+                try:
+                    PrintStyle.error(f"Memory recall failed: {e}")
+                except OSError:
+                    pass
 
         # task = self.agent.get_data(DATA_NAME_TASK_SOLUTIONS)
         # if task and not task.done():

--- a/python/helpers/print_style.py
+++ b/python/helpers/print_style.py
@@ -22,6 +22,7 @@ def _get_runtime():
 class PrintStyle:
     last_endline = True
     log_file_path = None
+    _log_file_handle = None
 
     def __init__(self, bold=False, italic=False, underline=False, font_color="default", background_color="default", padding=False, log_only=False, level="INFO", component="a0"):
         self.bold = bold
@@ -40,8 +41,12 @@ class PrintStyle:
             os.makedirs(logs_dir, exist_ok=True)
             log_filename = datetime.now().strftime("log_%Y%m%d_%H%M%S.html")
             PrintStyle.log_file_path = os.path.join(logs_dir, log_filename)
-            with open(PrintStyle.log_file_path, "w") as f:
-                f.write("<html><body style='background-color:black;font-family: Arial, Helvetica, sans-serif;'><pre>\n")
+            try:
+                PrintStyle._log_file_handle = open(PrintStyle.log_file_path, "w", encoding="utf-8")
+                PrintStyle._log_file_handle.write("<html><body style='background-color:black;font-family: Arial, Helvetica, sans-serif;'><pre>\n")
+                PrintStyle._log_file_handle.flush()
+            except OSError:
+                PrintStyle._log_file_handle = None
 
     def _get_rgb_color_code(self, color, is_background=False):
         try:
@@ -99,14 +104,25 @@ class PrintStyle:
             self.padding_added = True
 
     def _log_html(self, html):
-        with open(PrintStyle.log_file_path, "a", encoding='utf-8') as f: # type: ignore # add encoding='utf-8'
-            f.write(html)
+        try:
+            fh = PrintStyle._log_file_handle
+            if fh and not fh.closed:
+                fh.write(html)
+                fh.flush()
+        except OSError:
+            pass
 
     @staticmethod
     def _close_html_log():
-        if PrintStyle.log_file_path:
-            with open(PrintStyle.log_file_path, "a") as f:
-                f.write("</pre></body></html>")
+        fh = PrintStyle._log_file_handle
+        if fh and not fh.closed:
+            try:
+                fh.write("</pre></body></html>")
+                fh.flush()
+                fh.close()
+            except OSError:
+                pass
+        PrintStyle._log_file_handle = None
 
     @staticmethod
     def _format_args(args, sep):


### PR DESCRIPTION
## Summary

- **Persistent log file handle** in `print_style.py` — log file is opened once and kept open instead of open/close on every write, reducing FD churn from hundreds per message loop to 1
- **Fail-safe logging** — `_log_html()` swallows `OSError` to prevent cascading failures when FD limit is hit (previously error handlers crashed trying to log, which crashed retry handlers, etc.)
- **Raise FD soft limit** to 65536 at startup in `prepare.py` via `resource.setrlimit` — gives LanceDB headroom for concurrent vector searches
- **Resilient error handling** in `_50_recall_memories.py` and `_91_recall_wait.py` — `PrintStyle.error()` calls in exception handlers wrapped in `try/except OSError`

## Root cause

LanceDB (used by Cognee for vector search) opens many file descriptors during `brute_force_triplet_search` across multiple collections. The default Docker container ulimit (1024) was too low. When the limit was hit, the error cascaded because `print_style.py` tried to `open()` the log file in every error handler, each failing with the same `OSError(24)`, eventually crashing the entire agent monologue loop.

## Test plan

- [ ] Deploy to HA addon container and verify `Raised file descriptor limit` message in startup logs
- [ ] Send multiple messages in existing chat sessions — confirm no "Too many open files" errors
- [ ] Verify HTML log file is still written correctly after agent restart
- [ ] Check that memory recall gracefully returns empty results when Cognee search fails (instead of crashing)


Made with [Cursor](https://cursor.com)