### PR TITLE
chore: bump cognee to >=0.5.5

### DIFF
--- a/requirements2.txt
+++ b/requirements2.txt
@@ -1,3 +1,3 @@
 litellm==1.79.3
 openai>=1.99.5
-cognee>=0.5.4
+cognee>=0.5.5


### PR DESCRIPTION
## Summary

- Bump cognee from `>=0.5.4` to `>=0.5.5` (latest release, March 14 2026)

## What's new in cognee 0.5.5

- LanceDB async lock fixes (PR #1222) — resolves deadlocks during concurrent table creation
- Improved memify pipeline with triplet embeddings instead of coding rules
- DLT ingestion improvements with SQL safety, async handling, and concurrency controls
- Windows Docker entrypoint and Swagger UI fixes

## Test plan

- [ ] Verify agent starts without cognee init errors
- [ ] Send messages and confirm memory recall works
- [ ] Check cognee background worker (cognify/memify) runs without errors


Made with [Cursor](https://cursor.com)