### PR TITLE
fix: mitigate litellm httpx file descriptor leak (Too many open files)

### DIFF
--- a/models.py
+++ b/models.py
@@ -67,6 +67,36 @@ litellm.modify_params = True # helps fix anthropic tool calls by browser-use
 litellm.disable_aiohttp_transport = True  # use httpx instead — aiohttp has event-loop bugs that silently kill streams
 
 
+# --- Mitigate litellm httpx file descriptor leak ---
+# LiteLLM creates new httpx.AsyncClient instances per API call and relies on
+# GC to close them. In long-running async processes GC can't keep up, and the
+# accumulated orphaned TCP sockets exhaust the OS file-descriptor limit.
+# Fix: patch httpx client constructors to always use tight connection-pool
+# limits so each leaked client holds very few idle sockets.
+# (upstream: BerriAI/litellm#12872, #13220)
+import gc as _gc
+import httpx as _httpx
+
+_FD_SAFE_LIMITS = _httpx.Limits(
+    max_connections=50,
+    max_keepalive_connections=10,
+    keepalive_expiry=30,
+)
+
+_orig_async_client_init = _httpx.AsyncClient.__init__
+def _patched_async_client_init(self, **kwargs):
+    kwargs.setdefault("limits", _FD_SAFE_LIMITS)
+    _orig_async_client_init(self, **kwargs)
+_httpx.AsyncClient.__init__ = _patched_async_client_init  # type: ignore[method-assign]
+
+_orig_sync_client_init = _httpx.Client.__init__
+def _patched_sync_client_init(self, **kwargs):
+    kwargs.setdefault("limits", _FD_SAFE_LIMITS)
+    _orig_sync_client_init(self, **kwargs)
+_httpx.Client.__init__ = _patched_sync_client_init  # type: ignore[method-assign]
+# --- end httpx FD leak mitigation ---
+
+
 class _AiohttpLoopFilter(logging.Filter):
     def filter(self, record):
         msg = record.getMessage()
@@ -775,6 +805,7 @@ class LiteLLMChatWrapper(SimpleChatModel):
                         "chat_name": _mctx.get("chat_name"),
                     })
 
+                _gc.collect(0)
                 return result.response, result.reasoning
 
             except Exception as e:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -513,6 +513,57 @@ class TestLiteLLMEmbeddingWrapper:
             assert result == [0.1, 0.2]
 
 
+class TestHttpxFDLeakMitigation:
+    """Verify that the httpx connection-pool patch prevents unbounded FD growth.
+
+    LiteLLM creates a new httpx.AsyncClient per acompletion() call and never
+    closes them. Each holds open TCP sockets as file descriptors. The patch in
+    models.py overrides default connection limits so each leaked client keeps
+    very few idle connections, preventing FD exhaustion.
+    (upstream: BerriAI/litellm#12872, #13220)
+    """
+
+    @staticmethod
+    def _get_pool(client):
+        return client._transport._pool
+
+    def test_async_client_gets_safe_limits(self):
+        import httpx
+        from models import _FD_SAFE_LIMITS
+
+        client = httpx.AsyncClient()
+        pool = self._get_pool(client)
+        assert pool._max_connections == _FD_SAFE_LIMITS.max_connections
+        assert pool._max_keepalive_connections == _FD_SAFE_LIMITS.max_keepalive_connections
+
+    def test_sync_client_gets_safe_limits(self):
+        import httpx
+        from models import _FD_SAFE_LIMITS
+
+        client = httpx.Client()
+        pool = client._transport._pool
+        assert pool._max_connections == _FD_SAFE_LIMITS.max_connections
+        assert pool._max_keepalive_connections == _FD_SAFE_LIMITS.max_keepalive_connections
+
+    def test_explicit_limits_are_not_overridden(self):
+        import httpx
+
+        custom = httpx.Limits(max_connections=999, max_keepalive_connections=99)
+        client = httpx.AsyncClient(limits=custom)
+        pool = self._get_pool(client)
+        assert pool._max_connections == 999
+        assert pool._max_keepalive_connections == 99
+
+    def test_many_clients_have_bounded_keepalive(self):
+        import httpx
+        from models import _FD_SAFE_LIMITS
+
+        clients = [httpx.AsyncClient() for _ in range(50)]
+        for c in clients:
+            pool = self._get_pool(c)
+            assert pool._max_keepalive_connections == _FD_SAFE_LIMITS.max_keepalive_connections
+
+
 class TestLiteLLMChatWrapper:
     def test_llm_type_property(self):
         from models import LiteLLMChatWrapper, ModelConfig, ModelType, get_chat_model


### PR DESCRIPTION
## Summary

- **Root cause**: LiteLLM creates a new `httpx.AsyncClient` per `acompletion()` call and relies on GC to close them. In long-running async processes (like Agent Zero's message loop), GC can't keep up — orphaned TCP sockets accumulate and exhaust the OS file-descriptor limit, crashing the agent with `OSError: [Errno 24] Too many open files`.
- **Fix**: Monkey-patch `httpx.AsyncClient.__init__` and `httpx.Client.__init__` to enforce conservative connection-pool limits (`max_connections=50`, `max_keepalive_connections=10`, `keepalive_expiry=30s`). Each leaked client now holds ≤10 idle sockets instead of the default 20+. Also triggers `gc.collect(0)` after every LLM call for faster orphan reclamation.
- Upstream issues (closed as not_planned): [BerriAI/litellm#12872](https://github.com/BerriAI/litellm/issues/12872), [BerriAI/litellm#13220](https://github.com/BerriAI/litellm/issues/13220)

## Test plan

- [x] 4 new tests in `TestHttpxFDLeakMitigation` — verify connection limits are applied to async/sync clients, explicit limits aren't overridden, and 50 simultaneous clients all have bounded keepalive
- [ ] Deploy to staging HA addon, run extended conversation (100+ message loop iterations), monitor FD count with `ls /proc/1/fd | wc -l`
- [ ] Verify no regression in LLM call latency or streaming behavior


Made with [Cursor](https://cursor.com)