### PR TITLE
fix: stop Flask API request FD growth under Docker load

### DIFF
--- a/python/helpers/api.py
+++ b/python/helpers/api.py
@@ -81,6 +81,16 @@ class ApiHandler:
             PrintStyle.error(f"API error: {error}")
             return Response(response=error, status=500, mimetype="text/plain")
 
+    def handle_request_sync(self, request: Request) -> Response:
+        """
+        Run async API handlers through an explicit event loop per request.
+        This avoids relying on Flask's implicit async bridge under WSGI,
+        which can retain event-loop descriptors under heavy traffic.
+        """
+        import asyncio
+
+        return asyncio.run(self.handle_request(request))
+
     # get context to run agent zero in
     def use_context(self, ctxid: str, create_if_not_exists: bool = True):
         with self.thread_lock:

--- a/run_ui.py
+++ b/run_ui.py
@@ -5,6 +5,7 @@ import time
 import socket
 import struct
 from functools import wraps
+import inspect
 import threading
 import asyncio
 
@@ -122,9 +123,27 @@ def is_loopback_address(address):
 
 
 def requires_api_key(f):
+    if inspect.iscoroutinefunction(f):
+        @wraps(f)
+        async def decorated_async(*args, **kwargs):
+            from python.helpers.settings import get_settings
+            valid_api_key = get_settings()["mcp_server_token"]
+
+            if api_key := request.headers.get("X-API-KEY"):
+                if api_key != valid_api_key:
+                    return Response("Invalid API key", 401)
+            elif request.json and request.json.get("api_key"):
+                api_key = request.json.get("api_key")
+                if api_key != valid_api_key:
+                    return Response("Invalid API key", 401)
+            else:
+                return Response("API key required", 401)
+            return await f(*args, **kwargs)
+
+        return decorated_async
+
     @wraps(f)
-    async def decorated(*args, **kwargs):
-        # Use the auth token from settings (same as MCP server)
+    def decorated_sync(*args, **kwargs):
         from python.helpers.settings import get_settings
         valid_api_key = get_settings()["mcp_server_token"]
 
@@ -137,55 +156,90 @@ def requires_api_key(f):
                 return Response("Invalid API key", 401)
         else:
             return Response("API key required", 401)
-        return await f(*args, **kwargs)
+        return f(*args, **kwargs)
 
-    return decorated
+    return decorated_sync
 
 
 # allow only loopback addresses
 def requires_loopback(f):
+    if inspect.iscoroutinefunction(f):
+        @wraps(f)
+        async def decorated_async(*args, **kwargs):
+            if not is_loopback_address(request.remote_addr):
+                return Response(
+                    "Access denied.",
+                    403,
+                    {},
+                )
+            return await f(*args, **kwargs)
+
+        return decorated_async
+
     @wraps(f)
-    async def decorated(*args, **kwargs):
+    def decorated_sync(*args, **kwargs):
         if not is_loopback_address(request.remote_addr):
             return Response(
                 "Access denied.",
                 403,
                 {},
             )
-        return await f(*args, **kwargs)
+        return f(*args, **kwargs)
 
-    return decorated
+    return decorated_sync
 
 
 # require authentication for handlers
 def requires_auth(f):
-    @wraps(f)
-    async def decorated(*args, **kwargs):
-        user_pass_hash = login.get_credentials_hash()
-        # If no auth is configured, just proceed
-        if not user_pass_hash:
+    if inspect.iscoroutinefunction(f):
+        @wraps(f)
+        async def decorated_async(*args, **kwargs):
+            user_pass_hash = login.get_credentials_hash()
+            if not user_pass_hash:
+                return await f(*args, **kwargs)
+            if session.get('authentication') != user_pass_hash:
+                return redirect(url_for('login_handler'))
             return await f(*args, **kwargs)
 
+        return decorated_async
+
+    @wraps(f)
+    def decorated_sync(*args, **kwargs):
+        user_pass_hash = login.get_credentials_hash()
+        if not user_pass_hash:
+            return f(*args, **kwargs)
         if session.get('authentication') != user_pass_hash:
             return redirect(url_for('login_handler'))
+        return f(*args, **kwargs)
 
-        return await f(*args, **kwargs)
-
-    return decorated
+    return decorated_sync
 
 
 def csrf_protect(f):
+    if inspect.iscoroutinefunction(f):
+        @wraps(f)
+        async def decorated_async(*args, **kwargs):
+            token = session.get("csrf_token")
+            header = request.headers.get("X-CSRF-Token")
+            cookie = request.cookies.get("csrf_token_" + runtime.get_persistent_id()[:16])
+            sent = header or cookie
+            if not token or not sent or token != sent:
+                return Response("CSRF token missing or invalid", 403)
+            return await f(*args, **kwargs)
+
+        return decorated_async
+
     @wraps(f)
-    async def decorated(*args, **kwargs):
+    def decorated_sync(*args, **kwargs):
         token = session.get("csrf_token")
         header = request.headers.get("X-CSRF-Token")
         cookie = request.cookies.get("csrf_token_" + runtime.get_persistent_id()[:16])
         sent = header or cookie
         if not token or not sent or token != sent:
             return Response("CSRF token missing or invalid", 403)
-        return await f(*args, **kwargs)
+        return f(*args, **kwargs)
 
-    return decorated
+    return decorated_sync
 
 
 @webapp.route("/login", methods=["GET", "POST"])
@@ -436,8 +490,8 @@ def run():
         name = handler.__module__.split(".")[-1]
         instance = handler(app, lock)
 
-        async def handler_wrap() -> BaseResponse:
-            return await instance.handle_request(request=request)
+        def handler_wrap() -> BaseResponse:
+            return instance.handle_request_sync(request=request)
 
         if handler.requires_loopback():
             handler_wrap = requires_loopback(handler_wrap)

--- a/tests/api/test_http_auth_csrf.py
+++ b/tests/api/test_http_auth_csrf.py
@@ -122,3 +122,22 @@ def test_http_csrf_accepts_valid_cookie(monkeypatch) -> None:
     _set_csrf_cookie(client, "csrf-4")
     response = client.get("/secure")
     assert response.status_code == 200
+
+
+def test_http_decorators_work_for_sync_handlers(monkeypatch) -> None:
+    from run_ui import csrf_protect, requires_auth
+
+    monkeypatch.setattr("python.helpers.login.get_credentials_hash", lambda: "hash")
+
+    app = _make_app()
+
+    @app.get("/secure-sync")
+    @requires_auth
+    @csrf_protect
+    def secure_sync():
+        return Response("ok", status=200)
+
+    client = app.test_client()
+    _set_session(client, authentication="hash", csrf_token="csrf-sync")
+    response = client.get("/secure-sync", headers={"X-CSRF-Token": "csrf-sync"})
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Route API handlers through explicit sync dispatch (`asyncio.run`) instead of Flask's implicit async bridge for registered API endpoints.
- Make auth/loopback/CSRF decorators work for both sync and async handlers so the request pipeline remains consistent after dispatch change.
- Add regression coverage that decorators also work on sync handlers.

## Test plan
- [x] Build and run real app in Docker with OpenAI `gpt-4o-mini` for all models.
- [x] Reproduce baseline leak behavior on `/health` before fix (FD grows and does not settle).
- [x] Re-test after fix: `200x /health` keeps FD flat (delta 0, then -1 after settle).
- [x] Re-test `/poll` + `/history_get` burst after fix: FD delta 0.
- [x] Re-test `/message` workload after fix: no monotonic growth on repeated rounds (warmup spikes settle; end delta near baseline).
- [ ] `pytest -q tests/api/test_http_auth_csrf.py` in local host env (fails here due missing `uvicorn` dependency in host Python env).

Made with [Cursor](https://cursor.com)